### PR TITLE
Fix branch args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
   hooks:
     # Prevents commits to certain branches
     - id: no-commit-to-branch
-      args: ["--branch", "main", "master", ]
+      args: ["--branch", "main", "--branch", "master", ]
     # Checks that large files have not been added. Default cut-off for "large" files is 500kb.
     - id: check-added-large-files
     # Checks python syntax


### PR DESCRIPTION
\### Descriptions



Running pre-commit locally, I noted that it was failing due to a bad argument when trying to exclude branches. I've looked at NVDA repo to see that each Branch must be preceded by "--Branch". Now it's fixed.

