### PR TITLE
Update workflow dependancies

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -40,7 +40,7 @@ jobs:
     - name: building addon
       run: scons && scons pot
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@v6
       with:
         name: packaged_addon
         path: |
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: download releases files
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
     - name: Display structure of downloaded files
       run: ls -R
     - name: Calculate sha256


### PR DESCRIPTION
Two actions updated:
* Bump actions/download-artifact from 6 to 7
* Bump actions/upload-artifact from 5 to 6

### Note
On the contrary to the original repository, Dependabot does not automatically open PRs to allow such updates here.

@seanbudd could you please also check in the relevant sections if Dependabot alerts / Dependabot security updates are enabled, and if not, enable it?
This would avoid such manual PR in the future.

Thanks.
