### PR TITLE
Workflow runs produce add-on and .pot artifacts instead of a .zip

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -40,7 +40,14 @@ jobs:
         name: packaged_addon
         path: |
           ./*.nvda-addon
+        archive: false
+
+    - uses: actions/upload-artifact@v7
+      with:
+        name: translation_template
+        path: |
           ./*.pot
+        archive: false
 
   upload_release:
     runs-on: ubuntu-latest
@@ -50,8 +57,11 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v6
-    - name: download releases files
+    - name: download all artifacts
       uses: actions/download-artifact@v8
+      with:
+        path: .
+        merge-multiple: true
     - name: Display structure of downloaded files
       run: ls -R
     - name: Calculate sha256


### PR DESCRIPTION
### Change
It is now possible to have original files as workflow artifacts rather than a .zip containing all the produced files.
This PR implement this for the add-on template, so that you can download the .nvda-addon and the .pot directly, without having to unzip a package containing them.

### Test
Tested in [AddonTemplateTest](https://github.com/CyrilleB79/AddonTemplateTest/) repo, tag V2.2.
