### PR TITLE
Add missing Nepali locale mapping

### DIFF
--- a/.github/scripts/languageMappings.json
+++ b/.github/scripts/languageMappings.json
@@ -4,6 +4,7 @@
 	"es": "es-ES",
 	"es_CO": "es-CO",
 	"nb_NO": "nb",
+	"ne": "ne-NP",
 	"nn_NO": "nn-NO",
 	"pt_PT": "pt-PT",
 	"pt_BR": "pt-BR",


### PR DESCRIPTION
### Link to issue number:

None. This is a trivial change.

### Summary of the issue:

The locale mapping used during Crowdin synchronization is missing an entry for Nepali. NVDA uses the locale code `ne`, while Crowdin identifies the same locale as `ne-NP`. As a result, the Nepali locale cannot be matched during synchronization.

### Description of user facing changes:

None.

### Description of developer facing changes:

The Crowdin synchronization workflow can now correctly map the NVDA locale `ne` to the corresponding Crowdin locale `ne-NP`.

### Description of development approach

Added the missing entry to `languageMappings.json`, which is used by `crowdinSync.ps1` in the `crowdinL10n.yml` workflow to translate NVDA locale identifiers into their corresponding Crowdin locale identifiers during translation synchronization.

This follows the existing approach used for other locale identifiers whose naming differs between NVDA and Crowdin (for example `af_ZA` → `af` and `pt_BR` → `pt-BR`).

### Testing strategy:

* Verified that Crowdin supports Nepali as `ne-NP`.
* Verified that NVDA uses the locale identifier `ne`.
* Confirmed that adding the mapping is consistent with the existing exception mappings in `languageMappings.json`.

### Known issues with pull request:

None.
