### PR TITLE
Provide direct download link for l10nUtil.exe

### DIFF
--- a/docs/l10n/addonTranslators.md
+++ b/docs/l10n/addonTranslators.md
@@ -67,7 +67,7 @@ Poedit supports both:
 * Portable Object (`.po`) files used for interface translations.
 * XLIFF (`.xliff`) files used for documentation translations.
 
-After completing translations locally, files can be uploaded back to Crowdin using [l10nUtil.exe](https://github.com/nvaccess/nvdaL10n/releases/latest).
+After completing translations locally, files can be uploaded back to Crowdin using [l10nUtil.exe](https://github.com/nvaccess/nvdaL10n/releases/latest/download/l10nUtil.exe).
 
 ## Translating Interface Strings
 
@@ -97,7 +97,7 @@ When translating documentation:
 
 ## Uploading Offline Translations
 
-After translating files locally, they can be uploaded to Crowdin using [l10nUtil.exe](https://github.com/nvaccess/nvdaL10n/releases/latest)
+After translating files locally, they can be uploaded to Crowdin using [l10nUtil.exe](https://github.com/nvaccess/nvdaL10n/releases/latest/download/l10nUtil.exe)
 
 Examples:
 


### PR DESCRIPTION
### Issue

The link for l10nUtils.exe in translators documentation leads to a GitHub release webpage. Translators may not be used to GitHub and may have difficulties to find the tool in the page, among the assets to download.

### Solution
Rather provide a direct link to the file to download, as documented on GitHub's [Linking to releases](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases?utm_source=chatgpt.com) page.

---

Cc @nvdaes, @abdel792 